### PR TITLE
user 정보 로직 userContext로 이동, 페이지 새로고침 없이 user 다시 불러오도록 설정

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,7 +14,7 @@ const Login: React.FC = () => {
   const [id, setId] = useState("");
   const [pw, setPw] = useState("");
   const router = useRouter();
-  const { userType, setUserType, setIsLogin } = useUserContext();
+  const { userType, setUserType, setIsLogin, setUser } = useUserContext();
 
   // 아이디 입력 핸들러
   const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,33 +30,37 @@ const Login: React.FC = () => {
     const handleLogin = async (e: React.FormEvent) => {
         e.preventDefault(); // 폼 제출 시 페이지 리로드 방지
 
-        try {
-            // userType에 따라 데이터를 다르게 설정
-            const data =
-                userType === "mentor"
-                    ? { mentor_id: id, mentor_pw: pw } // 멘토일 때
-                    : { mentee_id: id, mentee_pw: pw }; // 멘티일 때
+        // userType에 따라 데이터를 다르게 설정
+        const data =
+          userType === "mentor"
+              ? { mentor_id: id, mentor_pw: pw } // 멘토일 때
+              : { mentee_id: id, mentee_pw: pw }; // 멘티일 때
 
-            // 로그인 요청
-            const res = await axios.post(
-                `http://localhost:8080/login/${userType}`,
-                data,
-                {
-                    withCredentials: true, // 쿠키 포함
-                }
-            );
-
-            // 로그인 성공
-            if (res.status === 200) {
-              setIsLogin(true);
-              setUserType(userType);
-              // 로그인 성공 후 리다이렉트
-              router.push("/with/us");
+        // 로그인 요청
+        axios.post(
+            `http://localhost:8080/login/${userType}`,
+            data,
+            {
+                withCredentials: true, // 쿠키 포함
             }
-            
-        } catch (error) {
-            console.error("로그인 실패 : ", error);
-        }
+        ).then(() => {
+            // 로그인 성공 요청
+            return axios({
+              url: `http://localhost:8080/login/${userType}/success`,
+              method: "GET",
+              withCredentials: true,
+            })
+        }).then((result) => {
+            // 로그인 성공
+            setIsLogin(true);
+            setUser(result.data, userType);
+            // 로그인 성공 후 리다이렉트
+            router.push("/with/us");
+
+        }).catch((error) => {
+          console.error("로그인 실패 : ", error);
+        });
+
     };
 
   return (

--- a/src/app/my/edit/page.tsx
+++ b/src/app/my/edit/page.tsx
@@ -11,7 +11,7 @@ import { useUserContext } from "@/context/UserContext";
 const Edit : React.FC = () => {
     const router = useRouter();
 
-    const { user } = useUserContext();
+    const { user, checkAccessToken } = useUserContext();
 
     const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -87,11 +87,16 @@ const Edit : React.FC = () => {
             // 모달 띄우기
             setModalMessage(result.data.message);
             setIsModalOpen(true);
+            
+            // 끝나고 여기 유저 정보를 새로 불러와야되는데 그걸 어케 하지?
+            checkAccessToken();
+
+
+            
         }).catch((error) => {
             console.log(error);
         })
 
-        // 끝나고 여기 유저 정보를 새로 불러와야되는데 그걸 어케 하지?
 
     }
 

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -7,68 +7,13 @@ import axios from "axios";
 import { useUserContext } from "@/context/UserContext";
 
 const Nav: React.FC = () => {
-  // const [isLogin, setIsLogin] = useState<boolean>(false);
-
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const { user, setUser, userType, isLogin, setIsLogin } = useUserContext();
-
-  console.log("여기", userType);
-  console.log(isLogin);
+  const { user, isLogin, checkAccessToken } = useUserContext();
 
   // 엑세스 토큰 유효성 검사
   useEffect(() => {
-    const checkAccessToken = async () => {
-      console.log("여기 들어오니");
-      console.log("여기서 유저타입은?", userType);
-      try {
-        await axios({
-          url: `http://localhost:8080/login/${userType}/accesstoken`,
-          method: "GET",
-          withCredentials: true,
-        });
-        // 엑세스 토큰이 유효한 경우 로그인 성공 요청
-        getLoginSuccess();
-      } catch (error) {
-        console.log("엑세스 토큰 검증 실패:", error);
-        // 엑세스 토큰이 유효하지 않으면 리프레시 토큰으로 새로운 엑세스 토큰을 발급받기
-        refreshAccessToken();
-      }
-    };
-
-    // 리프레시 토큰으로 새로운 엑세스 토큰 발급
-    const refreshAccessToken = async () => {
-      try {
-        await axios({
-          url: `http://localhost:8080/login/${userType}/refreshtoken`,
-          method: "GET",
-          withCredentials: true,
-        });
-        // 새로운 엑세스 토큰 발급 후 로그인 성공 요청
-        getLoginSuccess();
-      } catch (error) {
-        console.log("리프레시 토큰으로 엑세스 토큰 발급 실패:", error);
-        // 로그아웃 요청
-        setIsLogin(false);
-      }
-    };
-
-    // 로그인 성공 요청
-    const getLoginSuccess = async () => {
-      try {
-        const result = await axios({
-          url: `http://localhost:8080/login/${userType}/success`,
-          method: "GET",
-          withCredentials: true,
-        });
-        if (result.data) {
-          console.log("로그인 성공:", result.data); // 로그인 성공 데이터 확인
-          setIsLogin(true);
-          setUser(result.data, userType);
-        }
-      } catch (error) {
-        console.log("로그인 성공 요청 실패:", error);
-      }
-    };
+    console.log("nav user");
+    console.log(user);
 
     checkAccessToken();
   }, [isLogin]);
@@ -116,7 +61,6 @@ const Nav: React.FC = () => {
           {isLogin ? (
             <div className={styles.profileContainer}>
               <Link href={"/my"} className={styles.nicknameFrame}>
-                {/* 닉네임어디까지올라가는거예요오오오오옹 */}
                 {user?.nickname}
               </Link>
               <div className={styles.profileFrame}>

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { createContext, ReactNode, useContext, useState } from "react";
+import { createContext, ReactNode, useContext, useEffect, useState } from "react";
 import DBMenteeTrans from "@/utils/DBMenteeTrans";
 import DBMentorTrans from "@/utils/DBMentorTrans";
 import Cookies from "js-cookie";
+import axios from "axios";
 
 type UserContextType = {
   user: Mentor | Mentee | null; // user는 Mentor, Mentee, 또는 null일 수 있음
@@ -12,6 +13,8 @@ type UserContextType = {
   setUserType: (userType: string) => void;
   isLogin: boolean;
   setIsLogin: (isLogin: boolean) => void;
+  checkAccessToken : () => void;
+  refreshAccessToken : () => void;
 };
 
 // Context 생성
@@ -37,6 +40,53 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     Cookies.set('userType', userType, { expires: 1 });  // userType을 쿠키에 저장 (1일 동안 유효)
   };
 
+
+  const checkAccessToken = async () => {
+    console.log("여기 들어오니");
+    console.log("여기서 유저타입은?", userType);
+    console.log("로그인 여부?", isLogin);
+    try {
+      await axios({
+        url: `http://localhost:8080/login/${userType}/accesstoken`,
+        method: "GET",
+        withCredentials: true,
+      }).then((result) => {
+        console.log("login/userType/accessToken");
+        console.log(result.data.data);
+        setIsLogin(true);
+        handleSetUser(result.data.data, userType);
+        console.log("user?");
+        console.log(user);
+      });
+    } catch (error) {
+      console.log("엑세스 토큰 검증 실패:", error);
+      // 엑세스 토큰이 유효하지 않으면 리프레시 토큰으로 새로운 엑세스 토큰을 발급받기
+      refreshAccessToken();
+    }
+  };
+
+  // 리프레시 토큰으로 새로운 엑세스 토큰 발급
+  const refreshAccessToken = async () => {
+    try {
+      await axios({
+        url: `http://localhost:8080/login/${userType}/refreshtoken`,
+        method: "GET",
+        withCredentials: true,
+      });
+    } catch (error) {
+      console.log("리프레시 토큰으로 엑세스 토큰 발급 실패:", error);
+      // 로그아웃 요청
+      setIsLogin(false);
+    }
+  };
+
+
+  useEffect(() => {
+    checkAccessToken();
+  }, [])
+
+  
+
     return (
         <UserContext.Provider value={{
         user,
@@ -44,7 +94,9 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
         userType,
         setUserType: handleSetUserType,
         isLogin,
-        setIsLogin
+        setIsLogin,
+        checkAccessToken,
+        refreshAccessToken
       }}>
             {children}
         </UserContext.Provider>


### PR DESCRIPTION
login시 accessToken 발급 후 /success 경로로 요청 -> context에 유저 정보 저장
useContext에서 useEffect 내에 새로 user 정보 불러오는 로직 작성 -> 쿠키에 저장된 accessToken으로 정보 갱신(새로고침 후에도 로그인 유지)
프로필 수정 시 유저 정보 다시 불러오도록 context에 있는 checkAccessToken() 함수 호출 -> 유저 정보 갱신